### PR TITLE
added Mac-specific entries for directory infos to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ older-resources/iSAQB-CPSA-FL-Terms-DE-EN_Uli_Becker.xlsx
 older-resources/isaqb-glossar.docx
 isaqb-terms-translated_test.json
 .idea
+.DS_Store


### PR DESCRIPTION
Trivial but helpful change to .gitignore. Introduced via pull-request to see if this is the way we want to handle things 