### PR TITLE
Update terms A-C (typo and spelling)

### DIFF
--- a/manuscript/1-terms-A-C.md
+++ b/manuscript/1-terms-A-C.md
@@ -30,7 +30,7 @@ Category: Quality, ISO 25010
 {#term-acl}
 ### ACL
 Access Control Lists are a way to organize and store permissions of
-an [principal](#term-principal) for a specific entity. Beside implementations
+a [principal](#term-principal) for a specific entity. Beside implementations
 on an application level a typical example for an ACL is the management of file
 permissions on unix based operating systems.
 

--- a/manuscript/1-terms-A-C.md
+++ b/manuscript/1-terms-A-C.md
@@ -395,7 +395,7 @@ factors which is known by the system:
  * ownership (e.g. security token)
  * inherence (e.g. biometrics)
 
-For a stronger authentication mutiple factors can be requested or at least
+For a stronger authentication multiple factors can be requested or at least
 factors of two categories.
 
 Category: Security


### PR DESCRIPTION
Correct typo _"mutiple"_ and spelling _"an principal"_ in english version.