### PR TITLE
Correction of (most) external URLs (issue #124)

### DIFF
--- a/docs/1-terms/C/term-co-existence-quality-attribute.adoc
+++ b/docs/1-terms/C/term-co-existence-quality-attribute.adoc
@@ -17,7 +17,7 @@ Maß, in dem ein Produkt, während es sich eine gemeinsame Umgebung und
 Ressourcen mit anderen Produkten teilt, ohne nachteilige Auswirkungen
 auf andere Produkte seine geforderten Funktionen effizient erfüllen
 kann. Teilmerkmal von: <<term-compatibility-quality-attribute,Kompatibilität>>. Vgl. Website
-von link:https://iso25000.com/index.php/en/iso-25000-standards/iso-25010,[ISO 25010].
+von link:https://iso25000.com/index.php/en/iso-25000-standards/iso-25010[ISO 25010].
 
 
 

--- a/docs/1-terms/D/term-DDD.adoc
+++ b/docs/1-terms/D/term-DDD.adoc
@@ -6,7 +6,7 @@
 
 &quot;Domain-driven design (DDD) is an approach to developing software for complex needs by deeply connecting the implementation to an evolving model of the core business concepts.&quot;
 
-(quoted from link:https://dddcommunity.org/learning-ddd/what_is_ddd/[DDDCommunity]).
+(quoted from link:https://www.dddcommunity.org/learning-ddd/what_is_ddd/[DDDCommunity]).
 See <<ref-evans-2004,Evans-2004>>.
 
 See also:
@@ -26,7 +26,7 @@ See also:
 ==== Domain-Driven Design (DDD)
 
 &quot;Domain-Driven Design (DDD) ist ein Ansatz zur Softwareentwicklung für komplexe Anforderungen durch tiefreichende Verbindung der Implementierung mit einem sich evolvierenden Modell der Kerngeschäftskonzepte.&quot;
-(Übersetztes englisches Zitat von link:https://dddcommunity.org/learning-ddd/what_is_ddd/[DDDCommunity]).
+(Übersetztes englisches Zitat von link:https://www.dddcommunity.org/learning-ddd/what_is_ddd/[DDDCommunity]).
 
 Siehe <<ref-evans-2004,Evans-2004>>.
 

--- a/docs/1-terms/D/term-dependency-inversion.adoc
+++ b/docs/1-terms/D/term-dependency-inversion.adoc
@@ -3,7 +3,7 @@
 // tag::EN[]
 ==== Dependency Inversion Principle
 
-High level (abstract) elements should not depend upon low level (specific) elements. "Details should depend upon abstractions" (<<martin-2003,Martin-2003>>). One of the <<term-solid-principles,SOLID  principles>>, nicely explained by link:http://martinfowler.com/articles/dipInTheWild.html[Brett Schuchert], and closely related to the <<term-stable-dependencies-principle,SDP>> and <<term-stable-abstractions-principle,SAP>>.
+High level (abstract) elements should not depend upon low level (specific) elements. "Details should depend upon abstractions" (<<martin-2003,Martin-2003>>). One of the <<term-solid-principles,SOLID  principles>>, nicely explained by link:https://martinfowler.com/articles/dipInTheWild.html[Brett Schuchert], and closely related to the <<term-stable-dependencies-principle,SDP>> and <<term-stable-abstractions-principle,SAP>>.
 
 // end::EN[]
 

--- a/docs/1-terms/D/term-deployment-view.adoc
+++ b/docs/1-terms/D/term-deployment-view.adoc
@@ -7,7 +7,7 @@ Architectural view showing the technical infrastructure where a system or artifa
 deployed and executed.
 
 "This view defines the physical environment in which the system is intended to run, including the hardware environment your system needs (e.g., processing nodes, network interconnections, and disk storage facilities), the technical environment requirements for each node (or node type) in the system, and the mapping of your software elements to the runtime environment that will execute them."
-  (as defined by link:http://www.viewpoints-and-perspectives.info/home/viewpoints/deployment/[Rozanski+2011])
+  (as defined by link:https://www.viewpoints-and-perspectives.info/home/viewpoints/deployment/[Rozanski+2011])
 
 // end::EN[]
 
@@ -24,7 +24,7 @@ Speicherkapazitäten), der technischen Umgebungsanforderungen für jeden
 Knoten (oder Knotentyp) im System und des Mappings Ihrer
 Softwareelemente in Bezug auf die Laufzeitumgebung, die sie ausführt."
 (Übersetztes englisches Zitat von
-link:http://www.viewpoints-and-perspectives.info/home/viewpoints/deployment/[Rozanski+2011])
+link:https://www.viewpoints-and-perspectives.info/home/viewpoints/deployment/[Rozanski+2011])
 
 
 

--- a/docs/1-terms/D/term-design-principle.adoc
+++ b/docs/1-terms/D/term-design-principle.adoc
@@ -38,7 +38,7 @@ die folgenden *schlechten Eigenschaften* zu vermeiden:
 
 Diese Eigenschaften wurden von Robert Martin formuliert und stammen
 von
-link:https://www.oodesign.com/design-principles.html[OODesign.com]
+link:https://www.oodesign.com/design-principles[OODesign.com]
 
 
 

--- a/docs/1-terms/E/term-entropy.adoc
+++ b/docs/1-terms/E/term-entropy.adoc
@@ -11,7 +11,7 @@ For secure cryptographic operations it is mandatory to not only use random value
 The creation of high entropy on a computer system is non-trivial and can affect the performance of a
 system.
 
-See <<schneier-96>> and Whitewood Inc. on link:https://www.blackhat.com/docs/us-15/materials/us-15-Potter-Understanding-And-Managing-Entropy-Usage-wp.pdf["Understanding and Managing Entropy"] or link:https://www.sans.org/reading-room/whitepapers/vpns/randomness-entropy-introduction-874[SANS "Randomness and Entropy - An Introduction"].
+See <<schneier-96>> and Whitewood Inc. on link:https://www.blackhat.com/docs/us-15/materials/us-15-Potter-Understanding-And-Managing-Entropy-Usage-wp.pdf["Understanding and Managing Entropy"] or link:https://www.sans.org/white-papers/874/[SANS "Randomness and Entropy - An Introduction"].
 
 // end::EN[]
 
@@ -30,7 +30,7 @@ Entropie in einem Computersystem ist nicht trivial und kann die
 Systemleistung beeinträchtigen.
 
 Siehe <<schneier-96>> und Whitewood Inc. zu link:https://www.blackhat.com/docs/us-15/materials/us-15-Potter-Understanding-And-Managing-Entropy-Usage-wp.pdf[„Understanding and Managing Entropy"]
-oder link:https://www.sans.org/reading-room/whitepapers/vpns/randomness-entropy-introduction-874[SANS „Randomness and Entropy - An Introduction"].
+oder link:https://www.sans.org/white-papers/874/[SANS „Randomness and Entropy - An Introduction"].
 
 
 

--- a/docs/1-terms/I/term-iterative-development.adoc
+++ b/docs/1-terms/I/term-iterative-development.adoc
@@ -7,7 +7,7 @@
 
 "Development approach that _cycles_ through development phases,
 from gathering requirements to delivering functionality in a working release."
-(quoted from http://c2.com/cgi/wiki?IterativeDevelopment[c2-wiki])
+(quoted from https://wiki.c2.com/?IterativeDevelopment[c2-wiki])
 
 Such cycles are repeated to improve either functionality, quality or both.
 
@@ -23,7 +23,7 @@ Contrast to the <<term-waterfall-development,_Waterfall Development_>>.
 Zusammenstellung der Anforderungen bis zur Bereitstellung der
 Funktionalität in einem funktionierenden Release in _Zyklen_
 durchlaufen werden.&quot; (Übersetztes englisches Zitat von
-http://c2.com/cgi/wiki?IterativeDevelopment[c2-wiki]).
+https://wiki.c2.com/?IterativeDevelopment[c2-wiki]).
 
 Diese Zyklen werden zur Verbesserung von Funktionalität, Qualität oder
 beidem wiederholt.

--- a/docs/1-terms/M/term-microservice.adoc
+++ b/docs/1-terms/M/term-microservice.adoc
@@ -4,7 +4,7 @@
 ==== Microservice
 
 An architectural style, proposing to divide large systems into small units.
-"Microservices have to be implemented as virtual machines, as more light-weight alternatives such as Docker containers or as individual processes. Thereby they can easily be brought into production individually." (quoted from the (free) link:https://leanpub.com/microservices-primer[LeanPub booklet on Microservices] by link:http://microservices-book.com[Eberhard Wolff])
+"Microservices have to be implemented as virtual machines, as more light-weight alternatives such as Docker containers or as individual processes. Thereby they can easily be brought into production individually." (quoted from the (free) link:https://leanpub.com/microservices-primer[LeanPub booklet on Microservices] by link:https://microservices-book.com[Eberhard Wolff])
 
 // end::EN[]
 
@@ -17,7 +17,7 @@ als leichtere Alternativen, wie Docker-Container, oder als
 individuelle Prozesse implementiert werden. Dadurch können sie leicht
 einzeln in Produktion genommen werden." (Übersetztes englisches Zitat
 aus dem (kostenlosen) link:https://leanpub.com/microservices-primer[LeanPub booklet on Microservices]
-von link:http://microservices-book.com/[Eberhard Wolff].
+von link:https://microservices-book.com/[Eberhard Wolff].
 
 
 

--- a/docs/1-terms/M/term-model-driven-architecture.adoc
+++ b/docs/1-terms/M/term-model-driven-architecture.adoc
@@ -3,7 +3,7 @@
 // tag::EN[]
 ==== Model Driven Architecture (MDA)
 
-link:http://www.omg.org/mda/[Model Driven Architecture (MDA)] is an OMG-Standard for model based software development.
+link:https://www.omg.org/mda/[Model Driven Architecture (MDA)] is an OMG-Standard for model based software development.
 Definition: "An approach to IT system specification that separates the specification of functionality from the specification of the implementation of that functionality on a specific technology platform."
 
 // end::EN[]
@@ -11,7 +11,7 @@ Definition: "An approach to IT system specification that separates the specifica
 // tag::DE[]
 ==== Modellgetriebene Architektur
 
-link:http://www.omg.org/mda/[Modellgetriebene Architektur / Model Driven Architecture (MDA)]
+link:https://www.omg.org/mda/[Modellgetriebene Architektur / Model Driven Architecture (MDA)]
 ist ein
 OMG-Standard für die modellbasierte Softwareentwicklung. Definition:
 Ein Ansatz zur IT-Systemspezifikation, bei dem die Spezifikation der

--- a/docs/1-terms/P/term-principal.adoc
+++ b/docs/1-terms/P/term-principal.adoc
@@ -8,8 +8,9 @@ can be assigned permissions to. A principal can be a user but for example also
 other services or a process running on a system. The term is used in the 
 link:https://docs.oracle.com/javase/8/docs/api/java/security/Principal.html[Java environment]
 and throughout different authentication protocols (see 
-link:https://tools.ietf.org/html/rfc2744[GSSAPI RFC2744] or 
-link:https://tools.ietf.org/html/rfc4121[Kerberos RFC4121]).
+link:https://www.rfc-editor.org/rfc/rfc2744[GSSAPI RFC2744] or
+link:https://www.rfc-editor.org/rfc/rfc4121[Kerberos RFC4121]).
+
 
 
 
@@ -25,8 +26,8 @@ können Benutzer, aber auch andere Dienste oder ein auf einem System
 laufender Prozess sein. Der Begriff wird in der
 link:https://docs.oracle.com/javase/8/docs/api/java/security/Principal.html[Java-Umgebung]
 und in verschiedenen Authentifizierungsprotokollen verwendet (siehe
-link:https://tools.ietf.org/html/rfc2744[GSSAPI RFC2744] oder
-link:https://tools.ietf.org/html/rfc4121[Kerberos RFC4121]).
+link:https://www.rfc-editor.org/rfc/rfc2744[GSSAPI RFC2744] oder
+link:https://www.rfc-editor.org/rfc/rfc4121[Kerberos RFC4121]).
 
 
 

--- a/docs/1-terms/R/term-registry.adoc
+++ b/docs/1-terms/R/term-registry.adoc
@@ -4,7 +4,7 @@
 ==== Registry
 
 "A well-known object that other objects can use to find common objects and services." (quoted from
-  link:http://martinfowler.com/eaaCatalog/registry.html[PoEAA]). Often implemented as a _Singleton_ (also a
+  link:https://martinfowler.com/eaaCatalog/registry.html[PoEAA]). Often implemented as a _Singleton_ (also a
     well-known design pattern.)
 
 
@@ -16,7 +16,7 @@
 „Sehr bekanntes Objekt, das andere Objekte nutzen können, um
 gemeinsame Objekte und Dienste zu finden." (Übersetztes englisches
 Zitat
-link:http://martinfowler.com/eaaCatalog/registry.html[PoEAA]).
+link:https://martinfowler.com/eaaCatalog/registry.html[PoEAA]).
 Häufig als *Singleton* (auch ein bekanntes Entwurfsmuster)
 implementiert.
 

--- a/docs/1-terms/S/term-self-contained-system.adoc
+++ b/docs/1-terms/S/term-self-contained-system.adoc
@@ -4,7 +4,7 @@
 ==== Self Contained System (SCS)
 
 An architectural style, similar to <<term-microservice,Microservices>>. To quote from the site
-link:http://scs-architecture.org/[scs-architecture.org]:
+link:https://scs-architecture.org/[scs-architecture.org]:
 
 "The Self-contained System (SCS) approach is an architecture that focuses on a separation of the functionality into many independent systems, making the complete system a collaboration of many smaller software systems. This avoids the problem of large monoliths that grow constantly and eventually become unmaintainable"
 
@@ -15,7 +15,7 @@ link:http://scs-architecture.org/[scs-architecture.org]:
 ==== SCS (Self Contained System)
 
 Ein Architekturstil, ähnlich wie <<term-microservice,Microservices>>. Auf
-link:http://scs-architecture.org/[scs-architecture.org]
+link:https://scs-architecture.org/[scs-architecture.org]
 heißt es hierzu (übersetzt aus dem Englischen):
 
 „Der Ansatz Self-contained System (SCS) ist eine Architektur, die sich

--- a/docs/1-terms/S/term-software-architecture.adoc
+++ b/docs/1-terms/S/term-software-architecture.adoc
@@ -35,7 +35,7 @@ called _concepts_ or even _solution patterns_. Principles (concepts) are the fou
 
 
 The _Software Engineering Institute_
-maintains a link:http://www.sei.cmu.edu/architecture/start/glossary/classicdefs.cfm[collection of further definitions]
+maintains a link:https://www.sei.cmu.edu/architecture/start/glossary/classicdefs.cfm[collection of further definitions]
 
 Although the term often refers to the _software architecture of an IT system_, it is also used to refer to _software architecture as an engineering science_.
 
@@ -77,7 +77,7 @@ Die Schlüsselbegriffe dieser Definition bedürfen einer Erläuterung:
     *Konzepte* oder sogar *Lösungsmuster* genannt. Prinzipien (Konzepte)
     bilden die Grundlage für *konzeptionelle Integrität*.
 
-Das *Software Engineering Institute* führt eine link:http://www.sei.cmu.edu/architecture/start/glossary/classicdefs.cfm[Sammlung weiterer Definitionen]
+Das *Software Engineering Institute* führt eine link:https://www.sei.cmu.edu/architecture/start/glossary/classicdefs.cfm[Sammlung weiterer Definitionen]
 
 Auch wenn der Begriff sich oft auf die _Softwarearchitektur eines
 IT-Systems_ bezieht, wird er auch benutzt, um sich auf

--- a/docs/1-terms/T/term-template.adoc
+++ b/docs/1-terms/T/term-template.adoc
@@ -7,7 +7,7 @@ Standardized order of artifacts used in software development.
 It can help base other files, especially documents in a predefines
 structure without prescribing the content of these single files.
 
-A well known example of such templates is link:https://arc42.de/[arc42]
+A well known example of such templates is link:https://www.arc42.de/[arc42]
 
 // end::EN[]
 
@@ -19,7 +19,7 @@ Softwareentwicklung verwendet werden. Templates können dabei helfen,
 andere Dateien, insbesondere Dokumente, in eine vordefinierte Struktur
 einzubetten, ohne den Inhalt dieser einzelnen Dateien vorzugeben.
 
-Ein sehr bekanntes Template ist link:https://arc42.de/[arc42]
+Ein sehr bekanntes Template ist link:https://www.arc42.de/[arc42]
 
 
 

--- a/docs/1-terms/T/term-tls.adoc
+++ b/docs/1-terms/T/term-tls.adoc
@@ -10,7 +10,7 @@ It is widely used for secure communication on the internet and the foundation fo
 
 TLS started as an update to its predecessor SSL (Secure Socket Layer) Version
 3.0 and should be used now instead of SSL 
-link:https://tools.ietf.org/html/rfc7568[see RFC7568 "Deprecating Secure Sockets Layer Version 3.0"].
+link:https://www.rfc-editor.org/rfc/rfc7568[see RFC7568 "Deprecating Secure Sockets Layer Version 3.0"].
 
 
 
@@ -28,7 +28,7 @@ Kommunikation im Internet genutzt und bildet die Grundlage für HTTPS.
 
 TLS begann als Update seines Vorgängers SSL (Secure Socket Layer)
 Version 3.0 und sollte nun statt SSL verwendet werden 
-link:https://tools.ietf.org/html/rfc7568[siehe RFC7568 „Deprecating Secure Sockets Layer Version 3.0"].
+link:https://www.rfc-editor.org/rfc/rfc7568[siehe RFC7568 „Deprecating Secure Sockets Layer Version 3.0"].
 
 
 

--- a/docs/1-terms/T/term-togaf.adoc
+++ b/docs/1-terms/T/term-togaf.adoc
@@ -3,14 +3,14 @@
 // tag::EN[]
 ==== TOGAF
 
-link:http://www.opengroup.org/subjectareas/enterprise/togaf[_The Open Group Architecture Framework_] is a conceptual framework for planning and maintenance of enterprise IT architectures.
+link:https://www.opengroup.org/togaf[_The Open Group Architecture Framework_] is a conceptual framework for planning and maintenance of enterprise IT architectures.
 
 // end::EN[]
 
 // tag::DE[]
 ==== TOGAF
 
-link:http://www.opengroup.org/subjectareas/enterprise/togaf[_The Open Group Architecture Framework_]
+link:https://www.opengroup.org/togaf[_The Open Group Architecture Framework_]
 
 Konzeptioneller Rahmen für die Planung und Wartung von Unternehmens-IT-Architekturen.
 

--- a/docs/1-terms/U/term-uml.adoc
+++ b/docs/1-terms/U/term-uml.adoc
@@ -3,7 +3,7 @@
 // tag::EN[]
 ==== Unified Modeling Language (UML)
 
-link:http://uml.org[Unified Modeling Language (UML)] is a graphical language for visualizing, specifying and documenting the artifacts and structures of a software system.
+link:https://www.uml.org[Unified Modeling Language (UML)] is a graphical language for visualizing, specifying and documenting the artifacts and structures of a software system.
 
 * For building block views or the context view, use component diagrams, with either components, packages or classes to denote building blocks.
 * For runtime views, use sequence- or activity diagrams (with swimlanes). Object diagrams can theoretically be used, but are practically not adviced, as they become cluttered even for small scenarios.
@@ -14,7 +14,7 @@ link:http://uml.org[Unified Modeling Language (UML)] is a graphical language for
 // tag::DE[]
 ==== Unified Modeling Language (UML) 
 
-link:http://uml.org/[Unified Modeling Language / Vereinheitlichte Modellierungssprache (UML)]
+link:https://www.uml.org[Unified Modeling Language / Vereinheitlichte Modellierungssprache (UML)]
 
 Graphische Sprache zur Visualisierung, Spezifizierung und
 Dokumentation der Artefakte und Strukturen eines Softwaresystems.

--- a/docs/1-terms/W/term-waterfall-development.adoc
+++ b/docs/1-terms/W/term-waterfall-development.adoc
@@ -4,7 +4,7 @@
 
 ==== Waterfall Development
 
-Development approach "where you gather all the requirements up front, do all necessary design, down to a detailed level, then hand the specs to the coders, who write the code; then you do testing (possibly with a side trip to IntegrationHell) and deliver the whole thing in one big end-all release. Everything is big including the risk of failure." (quoted from the http://c2.com/cgi/wiki?IterativeDevelopment[C2 wiki])
+Development approach "where you gather all the requirements up front, do all necessary design, down to a detailed level, then hand the specs to the coders, who write the code; then you do testing (possibly with a side trip to IntegrationHell) and deliver the whole thing in one big end-all release. Everything is big including the risk of failure." (quoted from the https://wiki.c2.com/?IterativeDevelopment[C2 wiki])
 
 See also <<term-iterative-development,_iterative development_>>.
 
@@ -22,7 +22,7 @@ mit einem Abstecher in die Integrationshölle) und schließlich wird das
 Ganze mit einem großen abschließenden Release geliefert. Alles ist
 groß, auch die Gefahr des Scheiterns.&quot; (Übersetztes englisches Zitat
 aus
-http://c2.com/cgi/wiki?IterativeDevelopment[C2 wiki].
+link:https://wiki.c2.com/?IterativeDevelopment[C2 wiki].
 
 Siehe auch <<#term-iterative-development,_iterativen Entwicklung>>
 


### PR DESCRIPTION
Replace http links with https links
Replace moved links (301) with target link

Unfortunately, some external references can only be reached via HTTP.

- http://butunclebob.com/ArticleS.UncleBob.PrinciplesOfOod
- http://fmc-modeling.org/ 
- http://www.vincehuston.org/ood/oo_design_heuristics.html 

**What do we do with it? (Can/should we mark this somehow in the code?)**

Furthermore, some sources are no longer accessible/available at all. 

- http://www.cs.umd.edu/class/spring2003/cmsc838p/Design/criteria.pdf 
- http://codebetter.com/markneedham/2010/03/18/essential-and-accidental-complexity/  

**Fix within a new issue?**

All other links return the HTTP response code 200 or 301 when queried.