### PR TITLE
 Replace reference for ISO25010 draft with released 25010+25019

### DIFF
--- a/docs/8-references/references.adoc
+++ b/docs/8-references/references.adoc
@@ -56,7 +56,8 @@ A classic on design patterns.
 
 **I**
 
-- [[[ref-iso-25010, ISO-25010]]] ISO/IEC DIS 25010, Systems and software engineering — Systems and software Quality Requirements and Evaluation (SQuaRE) — Product quality model. Online: link:https://www.iso.org/obp/ui/#iso:std:iso-iec:25010
+- [[[ref-iso-25010, ISO-25010]]] ISO/IEC 25010:2023(en) Systems and software engineering — Systems and software Quality Requirements and Evaluation (SQuaRE) — Product quality model. Terms and definitions online: <https://www.iso.org/obp/ui/#iso:std:iso-iec:25010:ed-2:v1:en>
+- [[[ref-iso-25019, ISO-25019]]] ISO/IEC 25019:2023(en) Systems and software engineering — Systems and software Quality Requirements and Evaluation (SQuaRE) — Quality-in-use model. Terms and definitions online: <https://www.iso.org/obp/ui/#iso:std:iso-iec:25019:ed-1:v1:en>
 
 **K**
 


### PR DESCRIPTION
 - ISO25010:2023 has been released
 - added ISO25019:2023 because parts of the old norm ended up there and quality-in-use is relevant as well